### PR TITLE
feat: convert to streaming tools and add progress notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A comprehensive Model Context Protocol (MCP) server boilerplate built with TypeS
 - MCP Server implementation: HTTP-Based Streamable transport using `@modelcontextprotocol/sdk` with HTTP transport, session management, and tool execution.
 - OAuth authentication/3rd party authorization: Implements an OAuth server for MCP clients to process 3rd party authorization servers like Auth0, providing Dynamic Application Registration for MCP server.
 - Storage: Provide storage for MCP server to store data like OAuth sessions, tokens, etc.
-- Built-in sample tools: `echo`, `system-time`, `project` for demonstration.
+- Built-in sample tools: `echo`, `system-time`, `streaming`, `project` for demonstration.
 
 ## Why this project exists?
 
@@ -130,6 +130,10 @@ helm install mcp-server-boilerplate chrisleekr/mcp-server-boilerplate
      - JSON Web Token (JWT) Profile: Auth0
      - JSON Web Token (JWT) Signature Algorithm: RS256
    - Click on "Create"
+
+## TODO
+
+- [ ] Streaming is not working as expected. It returns the final result instead of streaming the data.
 
 ## Screenshots
 

--- a/src/core/mcpServer.ts
+++ b/src/core/mcpServer.ts
@@ -22,17 +22,27 @@ export class MCPServer {
       },
       {
         capabilities: {
-          logging: {},
+          logging: {
+            level: 'debug',
+          },
           tools: {},
+          notifications: {},
+          // Note: Saw somewhere, but it seems not working. Just leave it here for now.
+          experimental: {
+            streaming: true,
+            progressNotifications: true,
+          },
         },
       }
     );
 
     this.toolContext = {
       config: {},
+      server: this.server,
+      progressToken: '', // Placeholder for progress token
     };
 
-    setupToolHandlers(this.server, this.toolContext);
+    setupToolHandlers(this.toolContext);
     setupErrorHandling(this.server);
     loadTools();
   }
@@ -44,18 +54,35 @@ export class MCPServer {
       const port = config.server.http.port;
       const host = config.server.http.host;
 
-      this.httpServer.listen(port, host, () => {
+      const app = this.httpServer.listen(port, host, () => {
         loggingContext.log('info', 'MCP Server started successfully', {
           data: { host, port },
         });
       });
+
+      // Set keepAliveTimeout and headersTimeout for the http server
+      app.keepAliveTimeout = 60000;
+      app.headersTimeout = 65000;
     } catch (error) {
       loggingContext.log('error', 'Failed to start MCP Server', {
         error: {
           message: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
         },
       });
       throw error;
     }
+  }
+
+  public stop(): void {
+    if (this.httpServer) {
+      // Close HTTP server if it exists
+      loggingContext.log('info', 'Stopping MCP Server...');
+    }
+  }
+
+  // Getter for server instance (for tools that need direct access)
+  public getServerInstance(): Server {
+    return this.server;
   }
 }

--- a/src/core/server/errorHandling.ts
+++ b/src/core/server/errorHandling.ts
@@ -44,6 +44,7 @@ export function setupErrorHandling(server: Server): void {
         data: {
           error: {
             message: error instanceof Error ? error.message : 'Unknown error',
+            stack: error instanceof Error ? error.stack : undefined,
           },
         },
       });

--- a/src/core/server/http/handlers/mcpPost.ts
+++ b/src/core/server/http/handlers/mcpPost.ts
@@ -26,8 +26,11 @@ export function setupMCPPostHandler(
     void (async (): Promise<void> => {
       try {
         const requestBody = req.body as unknown;
-
         const sessionId = getSessionId(req);
+
+        loggingContext.log('debug', 'POST /mcp request body', {
+          data: { requestBody, sessionId },
+        });
 
         let transport: StreamableHTTPServerTransport;
 

--- a/src/core/server/http/middleware.ts
+++ b/src/core/server/http/middleware.ts
@@ -107,7 +107,7 @@ export function setupMiddleware(app: Application): void {
     loggingContext.init(context, () => {
       // clean up on response finish
       res.on('finish', () => {
-        const requestDuration = Date.now() - context.requestStartTime;
+        const requestDuration = Date.now() - requestStartTime;
         // If the request takes longer than 30 seconds, log a warning
         if (requestDuration > 30000) {
           loggingContext.log(
@@ -130,6 +130,7 @@ export function setupMiddleware(app: Application): void {
         }
       });
 
+      // Continue with the next middleware immediately
       next();
     });
   });

--- a/src/core/server/tools/index.ts
+++ b/src/core/server/tools/index.ts
@@ -1,1 +1,1 @@
-export { handleToolCall, loadTools, setupToolHandlers } from './handlers';
+export { loadTools, setupToolHandlers } from './handlers';

--- a/src/core/server/transport/manager.ts
+++ b/src/core/server/transport/manager.ts
@@ -26,7 +26,19 @@ export class TransportManager {
   public createTransport(): StreamableHTTPServerTransport {
     const newSessionId = randomUUID();
     const transport = new StreamableHTTPServerTransport({
+      /**
+       * Function that generates a session ID for the transport.
+       * The session ID SHOULD be globally unique and cryptographically secure (e.g., a securely generated UUID, a JWT, or a cryptographic hash)
+       *
+       * Return undefined to disable session management.
+       */
       sessionIdGenerator: (): string => newSessionId,
+      /**
+       * If true, the server will return JSON responses instead of starting an SSE stream.
+       * This can be useful for simple request/response scenarios without streaming.
+       * Default is false (SSE streams are preferred).
+       */
+      enableJsonResponse: false,
     });
 
     // Manually set the session ID to ensure it's available

--- a/src/tools/loader.ts
+++ b/src/tools/loader.ts
@@ -38,7 +38,7 @@ export class ToolLoader {
       this.registerTool(projectTool);
 
       this.loaded = true;
-      loggingContext.log('info', 'Successfully loaded tools1');
+      loggingContext.log('info', 'Successfully loaded tools');
     } catch (error: unknown) {
       loggingContext.log('error', 'Failed to load tools', {
         error: {

--- a/src/tools/loader.ts
+++ b/src/tools/loader.ts
@@ -4,6 +4,7 @@ import { Tool, ToolDefinition } from '@/tools/types';
 import { echoTool } from './echo';
 import { projectTool } from './project';
 import { toolRegistry } from './registry';
+import { streamingTool } from './streaming';
 import { systemTimeTool } from './system-time';
 
 export class ToolLoader {
@@ -24,19 +25,20 @@ export class ToolLoader {
     try {
       loggingContext.log('info', 'Loading tools...');
 
-      // Register core tools
+      // Register system time tool
       this.registerTool(systemTimeTool);
 
-      // Register example tools
+      // Register echo tool
       this.registerTool(echoTool);
+
+      // Register streaming tool
+      this.registerTool(streamingTool);
 
       // Register project tool
       this.registerTool(projectTool);
 
       this.loaded = true;
-      loggingContext.log('info', 'Successfully loaded tools', {
-        data: { tools: toolRegistry.list() },
-      });
+      loggingContext.log('info', 'Successfully loaded tools1');
     } catch (error: unknown) {
       loggingContext.log('error', 'Failed to load tools', {
         error: {

--- a/src/tools/notification.ts
+++ b/src/tools/notification.ts
@@ -1,0 +1,51 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+import { loggingContext } from '@/core/server/http/context';
+
+import { ProgressToken } from './types';
+
+export interface ProgressNotificationParams {
+  progressToken: ProgressToken;
+  progress: number;
+  total: number;
+  message: string;
+}
+
+/**
+ * Send a progress notification to the server
+ *
+ * BUT it seems not working as expected. Just leave it here for now.
+ * @param server - The server instance
+ * @param params - The progress notification parameters
+ */
+export async function sendProgressNotification(
+  server: Server,
+  params: ProgressNotificationParams
+): Promise<void> {
+  try {
+    loggingContext.log('info', 'Sending progress notification', {
+      data: { params },
+    });
+    await server.notification({
+      method: 'notifications/progress',
+      params: {
+        message: params.message,
+        progress: params.progress,
+        progressToken: params.progressToken,
+        total: params.total,
+      },
+    });
+    loggingContext.log('info', 'Progress notification sent', {
+      data: { params },
+    });
+  } catch (error: unknown) {
+    loggingContext.log('warn', 'Failed to send progress notification', {
+      data: {
+        error: {
+          message: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+      },
+    });
+  }
+}

--- a/src/tools/streaming/index.ts
+++ b/src/tools/streaming/index.ts
@@ -1,0 +1,281 @@
+/* eslint-disable max-lines-per-function */
+import { setTimeout } from 'node:timers/promises';
+
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { loggingContext } from '@/core/server/http/context';
+import {
+  ToolBuilder,
+  ToolContext,
+  ToolInputSchema,
+  ToolResult,
+} from '@/tools/types';
+
+import packageJson from '../../../package.json';
+import { sendProgressNotification } from '../notification';
+import { StreamingInput, StreamingInputSchema, StreamingOutput } from './types';
+
+/**
+ * Streaming tool that simulates real-time data streaming
+ *
+ * BUT it seems not working as expected. Just leave it here for now.
+ */
+async function* executeStreaming(
+  input: StreamingInput,
+  context: ToolContext
+): AsyncGenerator<ToolResult & { data?: StreamingOutput }> {
+  loggingContext.setContextValue('tool', 'streaming');
+  const startTime = Date.now();
+  const progressToken = context.progressToken;
+
+  try {
+    loggingContext.log('info', 'Starting streaming', {
+      data: { input, progressToken },
+    });
+
+    const validatedInput = StreamingInputSchema.parse(input);
+    const { dataType, count, intervalMs } = validatedInput;
+    const dataPoints: Array<{
+      timestamp: string;
+      index: number;
+      value: unknown;
+    }> = [];
+
+    // Send initial progress
+    if (context.server) {
+      await sendProgressNotification(context.server, {
+        progressToken,
+        progress: 0,
+        total: count,
+        message: `Starting ${dataType} streaming (${count} points, ${intervalMs}ms intervals)`,
+      });
+    }
+
+    // Generate and stream data points
+    for (let i = 1; i <= count; i++) {
+      // Generate data point based on type
+      const dataPoint = generateDataPoint(dataType, i);
+      const timestamp = new Date().toISOString();
+
+      dataPoints.push({
+        timestamp,
+        index: i,
+        value: dataPoint,
+      });
+
+      // Send progress update
+      if (context.server) {
+        await sendProgressNotification(context.server, {
+          progressToken,
+          progress: i,
+          total: count,
+          message: `Streamed ${i}/${count} ${dataType} data points`,
+        });
+      }
+
+      const executionTime = Date.now() - startTime;
+      const output: StreamingOutput = {
+        dataType,
+        count: validatedInput.count,
+        intervalMs,
+        totalDuration: executionTime,
+        dataPoints: [...dataPoints], // Create a copy for each yield
+        completedAt: timestamp,
+      };
+
+      // Yield intermediate result for streaming
+      yield {
+        success: true,
+        data: output,
+        executionTime,
+        timestamp,
+        metadata: {
+          toolVersion: packageJson.version,
+          dataType,
+          currentPoint: i,
+          totalPoints: count,
+          streamingEnabled: true,
+          isIntermediate: i < count,
+        },
+      };
+
+      loggingContext.log('debug', `Streaming data point ${i} generated`, {
+        data: { dataPoint, timestamp },
+      });
+
+      // Wait for the specified interval (except for the last iteration)
+      if (i < count) {
+        await setTimeout(intervalMs);
+      }
+    }
+
+    // Final completion notification
+    if (context.server) {
+      await sendProgressNotification(context.server, {
+        progressToken,
+        progress: count,
+        total: count,
+        message: `${dataType} streaming completed successfully`,
+      });
+    }
+
+    const totalExecutionTime = Date.now() - startTime;
+    const finalOutput: StreamingOutput = {
+      dataType,
+      count,
+      intervalMs,
+      totalDuration: totalExecutionTime,
+      dataPoints,
+      completedAt: new Date().toISOString(),
+    };
+
+    loggingContext.log('info', 'Streaming completed', {
+      data: { totalExecutionTime, pointsGenerated: dataPoints.length },
+    });
+
+    // Final yield with completion
+    yield {
+      success: true,
+      data: finalOutput,
+      executionTime: totalExecutionTime,
+      timestamp: new Date().toISOString(),
+      metadata: {
+        toolVersion: packageJson.version,
+        dataType,
+        totalPoints: count,
+        streamingEnabled: true,
+        isIntermediate: false,
+        completed: true,
+      },
+    };
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error occurred';
+
+    // Send error notification
+    if (context.server) {
+      await sendProgressNotification(context.server, {
+        progressToken,
+        progress: -1,
+        total: input.count,
+        message: `Streaming failed: ${errorMessage}`,
+      });
+    }
+
+    loggingContext.log('error', 'Streaming failed', {
+      data: { error: errorMessage, input, executionTime },
+    });
+
+    yield {
+      success: false,
+      error: errorMessage,
+      executionTime,
+      timestamp: new Date().toISOString(),
+      metadata: {
+        toolVersion: packageJson.version,
+        inputValidation: 'failed',
+      },
+    };
+  }
+}
+
+/**
+ * Generate sample data point based on data type
+ */
+function generateDataPoint(dataType: string, index: number): unknown {
+  switch (dataType) {
+    case 'metrics':
+      return {
+        cpu: Math.round(Math.random() * 100 * 100) / 100,
+        memory: Math.round((50 + Math.random() * 40) * 100) / 100,
+        disk: Math.round((20 + Math.random() * 30) * 100) / 100,
+        network: Math.round(Math.random() * 1000 * 100) / 100,
+      };
+    case 'stock_prices':
+      return {
+        symbol: 'DEMO',
+        price: Math.round((100 + Math.random() * 50) * 100) / 100,
+        volume: Math.floor(Math.random() * 10000),
+        change: Math.round((Math.random() * 10 - 5) * 100) / 100,
+      };
+    case 'sensor_data':
+      return {
+        temperature: Math.round((20 + Math.random() * 15) * 100) / 100,
+        humidity: Math.round((40 + Math.random() * 40) * 100) / 100,
+        pressure: Math.round((1000 + Math.random() * 50) * 100) / 100,
+        light: Math.floor(Math.random() * 1000),
+      };
+    case 'custom':
+    default:
+      return {
+        id: `data_${index}`,
+        value: Math.round(Math.random() * 1000),
+        category: ['A', 'B', 'C'][Math.floor(Math.random() * 3)],
+        active: Math.random() > 0.5,
+      };
+  }
+}
+
+/**
+ * Create and export the streaming tool
+ */
+export const streamingTool = new ToolBuilder<StreamingInput, StreamingOutput>(
+  'streaming'
+)
+  .description('Simulate real-time streaming data with live updates')
+  .inputSchema(zodToJsonSchema(StreamingInputSchema) as typeof ToolInputSchema)
+  .examples([
+    {
+      input: { dataType: 'metrics', count: 5, intervalMs: 1000 },
+      output: {
+        success: true,
+        data: {
+          dataType: 'metrics',
+          count: 5,
+          intervalMs: 1000,
+          totalDuration: 5000,
+          dataPoints: [
+            {
+              timestamp: '2024-01-15T10:30:00.000Z',
+              index: 1,
+              value: { cpu: 45.2, memory: 67.8, disk: 35.1, network: 234.5 },
+            },
+          ],
+          completedAt: '2024-01-15T10:30:05.000Z',
+        },
+      },
+      description: 'Stream system metrics data in real-time',
+    },
+    {
+      input: { dataType: 'stock_prices', count: 3, intervalMs: 2000 },
+      output: {
+        success: true,
+        data: {
+          dataType: 'stock_prices',
+          count: 3,
+          intervalMs: 2000,
+          totalDuration: 6000,
+          dataPoints: [
+            {
+              timestamp: '2024-01-15T10:30:00.000Z',
+              index: 1,
+              value: {
+                symbol: 'DEMO',
+                price: 125.45,
+                volume: 5678,
+                change: 2.3,
+              },
+            },
+          ],
+          completedAt: '2024-01-15T10:30:06.000Z',
+        },
+      },
+      description: 'Stream stock price data with live updates',
+    },
+  ])
+  .tags(['streaming', 'real-time', 'data'])
+  .version(packageJson.version)
+  .timeout(30000) // 30 second timeout
+  .streamingImplementation(executeStreaming)
+  .build();

--- a/src/tools/streaming/types.ts
+++ b/src/tools/streaming/types.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+/**
+ * Input schema for streaming tool
+ */
+export const StreamingInputSchema = z.object({
+  dataType: z
+    .enum(['metrics', 'stock_prices', 'sensor_data', 'custom'])
+    .default('metrics'),
+  count: z.number().min(1).max(50).default(5),
+  intervalMs: z.number().min(100).max(5000).default(1000),
+});
+
+export type StreamingInput = z.infer<typeof StreamingInputSchema>;
+
+/**
+ * Output schema for streaming tool
+ */
+export interface StreamingOutput {
+  dataType: string;
+  count: number;
+  intervalMs: number;
+  totalDuration: number;
+  dataPoints: Array<{
+    timestamp: string;
+    index: number;
+    value: unknown;
+  }>;
+  completedAt: string;
+}

--- a/test-streaming.sh
+++ b/test-streaming.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+# set -x
+
+test_tool() {
+    local mcp_session_id=$1
+    local tool_name=$2
+    local args=$3
+    local description=$4
+
+    echo ""
+    echo "Testing: $description"
+    echo "Tool: $tool_name"
+    echo "Args: $args"
+    echo "----------------------------------------"
+
+    curl -X POST http://localhost:3000/mcp \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -H "mcp-session-id: $mcp_session_id" \
+        -d "{
+            \"jsonrpc\": \"2.0\",
+            \"id\": $(date +%s),
+            \"method\": \"tools/call\",
+            \"params\": {
+                \"name\": \"$tool_name\",
+                \"arguments\": $args
+            }
+        }" | sed -n 's/^data: //p' | jq '.'
+
+    echo ""
+}
+
+# Initialize session first
+test_initialization() {
+    curl -i -X POST http://localhost:3000/mcp \
+        -H "Accept: application/json, text/event-stream" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {
+                    "sampling": {},
+                    "roots": {
+                        "listChanged": true
+                    },
+                    "notifications": {}
+                },
+                "clientInfo": {
+                    "name": "mcp-test-client",
+                    "version": "1.0.0"
+                }
+            }
+        }'
+}
+
+
+echo "Initializing session and extracting mcp-session-id header..."
+MCP_SESSION_ID=$(test_initialization | grep -i "mcp-session-id:" | sed 's/.*mcp-session-id:[[:space:]]*//' | tr -d '\r\n')
+if [ -z "$MCP_SESSION_ID" ]; then
+    echo "Failed to initialize session or retrieve mcp-session-id"
+    echo "Full response headers:"
+    echo "$INIT_RESPONSE" | head -20
+    exit 1
+fi
+echo "MCP Session ID extracted: $MCP_SESSION_ID"
+
+test_tool "$MCP_SESSION_ID" "streaming" '{"dataType": "stock_prices", "count": 10, "intervalMs": 1000}' "Stock prices stream"
+
+echo ""
+echo "Test completed"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline when developing.
-->

## Description

<!-- Describe your changes in detail -->
In this PR, I've refactored current tool implementation to streaming tool and added progress notification.

Note: But both of features are not working as expected.

- Now, tool execution is using `AsyncGenerator` for streaming results; however, for some reason, it's not streaming the result.
- I've also implemented progress notification, but it seems not showing in MCP inspector.
- I also added `keepAliveTimeout` and `headersTimeout` for the HTTP server.

## Related Issues

<!-- Link any related issues here -->

- Closes #(issue number)

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots/Recordings

<!-- Add screenshots or recordings if your changes affect the UI -->
